### PR TITLE
feat/datalinks: use internal grafana var for dashboard url

### DIFF
--- a/grafanacloud/monitoring/Billing_Usage.json
+++ b/grafanacloud/monitoring/Billing_Usage.json
@@ -124,7 +124,7 @@
       "title": "GrafanaCloud Billing/Usage",
       "tooltip": "GrafanaCloud Billing/Usage",
       "type": "link",
-      "url": "/d/ac2b8a89-d4bd-496c-880d-ef59087d97d5/billing-usage?orgId=1"
+      "url": "/d/${__dashboard.uid}/${__dashboard}"
     },
     {
       "asDropdown": false,

--- a/opentelemetry/dotnet/webapi/OpenTelemetry dotnet webapi.json
+++ b/opentelemetry/dotnet/webapi/OpenTelemetry dotnet webapi.json
@@ -1328,7 +1328,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "./d/otel-dotnet-webapi-per-instance/opentelemetry-dotnet-webapi-per-instance?${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&var-host_name=${__field.labels.host_name}&${__url_time_range}"
+              "url": "./d/${__dashboard.uid}/${__dashboard}?${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&var-host_name=${__field.labels.host_name}&${__url_time_range}"
             },
             {
               "targetBlank": true,
@@ -2887,7 +2887,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "./d/otel-dotnet-webapi-per-instance/opentelemetry-dotnet-webapi-per-instance?${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&var-host_name=${__field.labels.host_name}&${__url_time_range}"
+              "url": "./d/${__dashboard.uid}/${__dashboard}?${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&var-host_name=${__field.labels.host_name}&${__url_time_range}"
             },
             {
               "targetBlank": true,

--- a/opentelemetry/java/springboot/OpenTelemetry JVM Micrometer.json
+++ b/opentelemetry/java/springboot/OpenTelemetry JVM Micrometer.json
@@ -215,7 +215,7 @@
           "links": [
             {
               "title": "view ${__field.labels.status}",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&${host_name:queryparam}&${uri:queryparam}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&${host_name:queryparam}&${uri:queryparam}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -466,7 +466,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name}${__field.labels.uri}: ${__field.labels.status} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -621,7 +621,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name}${__field.labels.uri}: ${__field.labels.status} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             },
             {
               "targetBlank": true,
@@ -743,7 +743,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name}${__field.labels.uri}: ${__field.labels.status} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             },
             {
               "targetBlank": true,
@@ -968,7 +968,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1076,7 +1076,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1184,7 +1184,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1293,7 +1293,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1413,7 +1413,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1563,7 +1563,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1671,7 +1671,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1780,7 +1780,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -1904,7 +1904,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2055,7 +2055,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2181,7 +2181,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2333,7 +2333,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2485,7 +2485,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2611,7 +2611,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2797,7 +2797,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -2935,7 +2935,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -3035,7 +3035,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "unitScale": true
@@ -3151,7 +3151,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -3286,7 +3286,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],
@@ -3412,7 +3412,7 @@
             {
               "targetBlank": true,
               "title": "${__field.labels.host_name} details",
-              "url": "/d/otel-jvm-micrometer/opentelemetry-jvm-micrometer?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
+              "url": "/d/${__dashboard.uid}/${__dashboard}?${prom_ds:queryparam}&${loki_ds:queryparam}&${service_name:queryparam}&${deployment_environment:queryparam}&${service_version:queryparam}&${top:queryparam}&${saturation:queryparam}&${jvm_memory_used_id:queryparam}&${jvm_buffer_memory_used_id:queryparam}&var-host_name=${__field.labels.host_name}&var-uri=${__field.labels.uri}&var-status=${__field.labels.status}&${__url_time_range}"
             }
           ],
           "mappings": [],


### PR DESCRIPTION
when a dashboard template is imported the dashboard id is different and the internal grafana vars `${__dashboard.uid}/${__dashboard}` should be used in datalinks